### PR TITLE
fix bind values mismatch after merging common where values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ### RailsOr [Unreleased] 
 
-- No changes.
+- Fix bind values mismatch after merging common where values. [[#19](https://github.com/khiav223577/rails_or/pull/19)] @khiav223577
 <br><br>
 
 ### RailsOr [1.1.4] - (April 1, 2017)

--- a/lib/rails_or/where_binding_mixs.rb
+++ b/lib/rails_or/where_binding_mixs.rb
@@ -1,15 +1,25 @@
 class RailsOr::WhereBindingMixs
   attr_reader :where_values
   attr_reader :bind_values
+
   def initialize(where_values, bind_values)
     @where_values = where_values
     @bind_values = bind_values
   end
-  def merge!(other)
-    @where_values += other.where_values
-    @bind_values += other.bind_values
-    return self
+
+  def +(other)
+    self.class.new(@where_values + other.where_values, @bind_values + other.bind_values)
   end
+
+  def -(other)
+    self.select{|node| !other.where_values.include?(node) }
+  end
+
+  def &(other)
+    common_where_values = @where_values & other.where_values
+    return self.select{|node| common_where_values.include?(node) }
+  end
+
   def select
     binds_index = 0
     new_bind_values = []

--- a/lib/rails_or/where_binding_mixs.rb
+++ b/lib/rails_or/where_binding_mixs.rb
@@ -1,0 +1,28 @@
+class RailsOr::WhereBindingMixs
+  attr_reader :where_values
+  attr_reader :bind_values
+  def initialize(where_values, bind_values)
+    @where_values = where_values
+    @bind_values = bind_values
+  end
+  def merge!(other)
+    @where_values += other.where_values
+    @bind_values += other.bind_values
+    return self
+  end
+  def select
+    binds_index = 0
+    new_bind_values = []
+    new_where_values = @where_values.select do |node|
+      flag = yield(node)
+      if not node.is_a?(String)
+        binds_contains = node.grep(Arel::Nodes::BindParam).size
+        pre_binds_index = binds_index
+        binds_index += binds_contains
+        (pre_binds_index...binds_index).each{|i| new_bind_values << @bind_values[i] } if flag
+      end
+      next flag
+    end
+    return self.class.new(new_where_values, new_bind_values)
+  end
+end

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -42,14 +42,16 @@ class RailsOrTest < Minitest::Test
 #--------------------------------
 #  Common condition
 #--------------------------------
-  if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('5.0.0')
-    def test_or_with_common_where #Rails 5 doesn't support this
-      expected = Post.where('id = 1 and (title = ? or title = ?)', "John's post1", "John's post2").to_a
-      target = Post.where('id = 1').where(:title => "John's post1").or(Post.where('id = 1').where(:title => "John's post2"))
-      assert_equal expected, target.to_a
-      assert_equal 1, target.to_sql.scan('id = 1').size
-    end
+  def test_or_with_common_where 
+    expected = Post.where('id = 1 and (title = ? or title = ?)', "John's post1", "John's post2").to_a
+    target = Post.where('id = 1').where(:title => "John's post1").or(Post.where('id = 1').where(:title => "John's post2"))
+    assert_equal expected, target.to_a
+
+    # Rails 5 native #or doesn't merge same condition
+    expected = (Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('5.0.0') ? 1 : 2)
+    assert_equal expected, target.to_sql.scan('id = 1').size
   end
+
   def test_or_with_unneeded_brackets
     #Wrong: SELECT "users".* FROM "users"  WHERE (("users"."id" = 1) OR ("users"."id" = 2))
     #Correct: SELECT "users".* FROM "users"  WHERE ("users"."id" = 1 OR "users"."id" = 2)

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -42,14 +42,21 @@ class RailsOrTest < Minitest::Test
 #--------------------------------
 #  Common condition
 #--------------------------------
-  def test_or_with_common_where 
+  def test_or_with_shared_where 
     expected = Post.where('id = 1 and (title = ? or title = ?)', "John's post1", "John's post2").to_a
     target = Post.where('id = 1').where(:title => "John's post1").or(Post.where('id = 1').where(:title => "John's post2"))
     assert_equal expected, target.to_a
 
-    # Rails 5 native #or doesn't merge same condition
+    # Rails 5's native #or implementation doesn't merge same condition
     expected = (Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('5.0.0') ? 1 : 2)
     assert_equal expected, target.to_sql.scan('id = 1').size
+  end
+
+  def test_or_with_shared_where_and_binding_values
+    p1 = Post.where(id: 1)
+    expected = p1.where('title = ? or title = ?', "John's post1", "John's post2").to_a
+    target = p1.where(:title => "John's post1").or(p1.where(:title => "John's post2"))
+    assert_equal expected, target.to_a
   end
 
   def test_or_with_unneeded_brackets


### PR DESCRIPTION
```rb
u = User.where(id: 1)
u.where(account: 'a').or(u1.where(email: 'b'))
```
### Wrong:
```rb
SELECT `users`.* FROM `users` WHERE 
  `users`.`id` = 1 AND (`users`.`account` = 'a' OR `users`.`email` = 1)
```
### Correct:
```rb
SELECT `users`.* FROM `users` WHERE 
  `users`.`id` = 1 AND (`users`.`account` = 'a' OR `users`.`email` = 'b')
```