### PR TITLE
Better Rails 5 Support

### DIFF
--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -65,11 +65,19 @@ class ActiveRecord::Relation
   def rails_or_parse_parameter(*other)
     other = other.first if other.size == 1
     case other
-    when Hash   ; klass.where(other)
-    when Array  ; klass.where(other)
-    when String ; klass.where(other)
+    when Hash   ; rails_or_spwan_relation(other)
+    when Array  ; rails_or_spwan_relation(other)
+    when String ; rails_or_spwan_relation(other)
     else        ; other
     end
+  end
+
+  def rails_or_spwan_relation(condition) # for rails 5
+    relation = klass.where(condition)
+    relation.joins_values = self.joins_values
+    relation.limit_value = self.limit_value
+    relation.group_values = self.group_values
+    return relation
   end
 
   def rails_or_get_current_scope

--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -41,9 +41,8 @@ class ActiveRecord::Relation
     end
   end
 
-  def or_not(*args)
-    raise 'This method is not support in Rails 3' if IS_RAILS3_FLAG
-    return self.or(klass.where.not(*args))
+  def or_not(*args) # Works in Rails 4+
+    self.or(klass.where.not(*args))
   end
 
   def or_having(hash)
@@ -72,8 +71,9 @@ class ActiveRecord::Relation
     end
   end
 
-  def rails_or_spwan_relation(method, condition) # for rails 5
+  def rails_or_spwan_relation(method, condition)
     relation = klass.send(method, condition)
+    # The following is for rails 5+
     relation.joins_values = self.joins_values
     relation.limit_value = self.limit_value
     relation.group_values = self.group_values
@@ -86,8 +86,8 @@ class ActiveRecord::Relation
 
   def rails_or_get_current_scope
     return self.clone if IS_RAILS3_FLAG
-    #ref: https://github.com/rails/rails/blob/17ef58db1776a795c9f9e31a1634db7bcdc3ecdf/activerecord/lib/active_record/scoping/named.rb#L26
-    #return self.all # <- cannot use this because some gem changes this method's behavior
+    # ref: https://github.com/rails/rails/blob/17ef58db1776a795c9f9e31a1634db7bcdc3ecdf/activerecord/lib/active_record/scoping/named.rb#L26
+    # return self.all # <- cannot use this because some gem changes this method's behavior
     return (self.current_scope || self.default_scoped).clone
   end
 end

--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -77,6 +77,7 @@ class ActiveRecord::Relation
     relation.joins_values = self.joins_values
     relation.limit_value = self.limit_value
     relation.group_values = self.group_values
+    relation.distinct_value = self.distinct_value
     return relation
   end
 

--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -46,8 +46,8 @@ class ActiveRecord::Relation
     return self.or(klass.where.not(*args))
   end
 
-  def or_having(*args)
-    self.or(klass.having(*args))
+  def or_having(hash)
+    self.or(rails_or_spwan_relation(:having, hash))
   end
 
   private
@@ -65,15 +65,15 @@ class ActiveRecord::Relation
   def rails_or_parse_parameter(*other)
     other = other.first if other.size == 1
     case other
-    when Hash   ; rails_or_spwan_relation(other)
-    when Array  ; rails_or_spwan_relation(other)
-    when String ; rails_or_spwan_relation(other)
+    when Hash   ; rails_or_spwan_relation(:where, other)
+    when Array  ; rails_or_spwan_relation(:where, other)
+    when String ; rails_or_spwan_relation(:where, other)
     else        ; other
     end
   end
 
-  def rails_or_spwan_relation(condition) # for rails 5
-    relation = klass.where(condition)
+  def rails_or_spwan_relation(method, condition) # for rails 5
+    relation = klass.send(method, condition)
     relation.joins_values = self.joins_values
     relation.limit_value = self.limit_value
     relation.group_values = self.group_values

--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -80,6 +80,7 @@ class ActiveRecord::Relation
     relation.distinct_value = self.distinct_value
     relation.order_values = self.order_values
     relation.offset_value = self.offset_value
+    relation.references_values = self.references_values
     return relation
   end
 

--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -78,6 +78,8 @@ class ActiveRecord::Relation
     relation.limit_value = self.limit_value
     relation.group_values = self.group_values
     relation.distinct_value = self.distinct_value
+    relation.order_values = self.order_values
+    relation.offset_value = self.offset_value
     return relation
   end
 

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -96,30 +96,30 @@ class RailsOrTest < Minitest::Test
 #--------------------------------
 #  having
 #--------------------------------
-  def test_or_with_having #Rails 5 doesn't support this
+  def test_or_with_having
     expected = Post.group(:user_id).having("COUNT(*) = 1 OR COUNT(*) = 2").to_a
-    assert_equal expected, Post.group(:user_id).having("COUNT(*) = 1").or(Post.having("COUNT(*) = 2")).to_a
+    assert_equal expected, Post.group(:user_id).having("COUNT(*) = 1").or(Post.group(:user_id).having("COUNT(*) = 2")).to_a
     assert_equal expected, Post.group(:user_id).having("COUNT(*) = 1").or_having("COUNT(*) = 2").to_a
   end
 
-  def test_or_with_join_and_having #Rails 5 doesn't support this
+  def test_or_with_join_and_having
     expected = User.joins(:posts).group(:user_id).having("COUNT(*) = 1 OR COUNT(*) > 1").to_a
     assert_equal expected, User.joins(:posts).group(:user_id).having("COUNT(*) > 1").or_having("COUNT(*) = 1").to_a
   end
 #--------------------------------
 #  uniq / limit / offset / order
 #--------------------------------
-  def test_or_with_limit #Rails 5 doesn't support this
+  def test_or_with_limit
     expected = Post.where('user_id = 1 OR user_id = 2').limit(4).to_a
     assert_equal expected, Post.limit(4).where(:user_id => 1).or(:user_id => 2).to_a
   end
 
-  def test_or_with_uniq #Rails 5 doesn't support this
+  def test_or_with_uniq
     expected = Post.distinct.where('user_id = 1 OR user_id = 2').pluck(:user_id)
     assert_equal expected, Post.distinct.where(:user_id => 1).or(:user_id => 2).pluck(:user_id)
   end
 
-  def test_or_with_offset #Rails 5 doesn't support this
+  def test_or_with_offset
     expected = Post.where('user_id = 1 OR user_id = 2').offset(3).first
     assert_equal expected, Post.offset(3).where(:user_id => 1).or(:user_id => 2).first
   end

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -4,7 +4,7 @@ class RailsOrTest < Minitest::Test
   def setup
     
   end
-  
+
   def test_that_it_has_a_version_number
     refute_nil ::RailsOr::VERSION
   end
@@ -121,38 +121,38 @@ class RailsOrTest < Minitest::Test
 
   def test_or_with_offset #Rails 5 doesn't support this
     expected = Post.where('user_id = 1 OR user_id = 2').offset(3).first
-    assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).offset(3).first
+    assert_equal expected, Post.offset(3).where(:user_id => 1).or(:user_id => 2).first
   end
 
-  def test_or_with_order #Rails 5 doesn't support this
+  def test_or_with_order
     expected = Post.where('user_id = 1 OR user_id = 2 OR user_id = 3').order('user_id desc').pluck(:user_id)
-    assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).or(:user_id => 3).order('user_id desc').pluck(:user_id)
+    assert_equal expected, Post.order('user_id desc').where(:user_id => 1).or(:user_id => 2).or(:user_id => 3).pluck(:user_id)
   end
 #--------------------------------
 #  logic order
 #--------------------------------
-  def test_A_and_B_or_C #(A && B) || C, C || (B && A)
+  def test_A_and_B_or_C # (A && B) || C, C || (B && A)
     expected = Post.where('(user_id = ? AND title = ?) OR user_id = ?', 1, "John's post1", 2).to_a
     assert_equal expected, Post.where(:user_id => 1).where(:title => "John's post1").or(:user_id => 2).to_a
     assert_equal expected, Post.where(:user_id => 2).or(Post.where(:title => "John's post1").where(:user_id => 1)).to_a
   end
 
-  def test_A_or_B_and_C #(A || B) && C
+  def test_A_or_B_and_C # (A || B) && C
     expected = Post.where('(user_id = ? OR user_id = ?) AND title LIKE ?', 1, 2, "John's %").to_a
     assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).where('title LIKE ?', "John's %").to_a
   end
 
   if Gem::Version.new(ActiveRecord::VERSION::STRING) > Gem::Version.new('4.0.2')
-    def test_A_and_not_B_or_C #(A && !B) || C, C || (!B && A)
+    def test_A_and_not_B_or_C # (A && !B) || C, C || (!B && A)
       expected = Post.where('(user_id = ? AND NOT title = ?) OR user_id = ?', 1, "John's post1", 2).to_a
       assert_equal expected, Post.where(:user_id => 1).where.not(:title => "John's post1").or(:user_id => 2).to_a
       assert_equal expected, Post.where(:user_id => 2).or(Post.where.not(:title => "John's post1").where(:user_id => 1)).to_a
     end
-    def test_A_or_B_and_not_C #(A || B) && !C
+    def test_A_or_B_and_not_C # (A || B) && !C
       expected = Post.where('(user_id = ? OR user_id = ?) AND title NOT LIKE ?', 1, 2, "John's %").to_a
       assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).where.not('title LIKE ?', "John's %").to_a
     end
-    def test_A_and_not_B_or_not_C #(A && !B) || !C, !C || (!B && A)
+    def test_A_and_not_B_or_not_C # (A && !B) || !C, !C || (!B && A)
       expected = Post.where('(title LIKE ? AND user_id != ?) OR title NOT LIKE ?', 1, "Kathenrie's %", "Pearl's %").to_a
       assert_equal expected, Post.where('title LIKE ?', "Kathenrie's %").where.not(:user_id => 1).or_not('title LIKE ?', "Pearl's %").to_a
       assert_equal expected, Post.where.not('title LIKE ?', "Pearl's %").or(Post.where.not(:user_id => 1).where('title LIKE ?', "Kathenrie's %")).to_a
@@ -161,7 +161,7 @@ class RailsOrTest < Minitest::Test
 #--------------------------------
 #  Nested
 #--------------------------------
-  def test_nested_or #(A && (B || C)) || D, ((B || C) && A) || D
+  def test_nested_or # (A && (B || C)) || D, ((B || C) && A) || D
     expected = Post.where('(title like ?) AND (start_time IS NULL OR start_time > ?) OR (title = ?)', 'John%', Time.parse('2016/1/15'), "Pearl's post1").pluck(:title)
     p1 = Post.with_title_like('John%').where('start_time IS NULL OR start_time > ?', Time.parse('2016/1/15'))
     assert_equal expected, p1.or(:title => "Pearl's post1").pluck(:title)
@@ -172,7 +172,7 @@ class RailsOrTest < Minitest::Test
 #--------------------------------
 #  Association test
 #--------------------------------
-  def test_two_has_many_result #model.others1 || model.others2
+  def test_two_has_many_result # model.others1 || model.others2
     user = User.where(:name => 'John').first
     assert_equal user.sent_messages.or(user.received_messages).pluck(:content), [
       "user1 send to user2", 

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -8,9 +8,10 @@ class RailsOrTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::RailsOr::VERSION
   end
-#--------------------------------
-#  Parameter check
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● Parameter check
+  # ----------------------------------------------------------------
   def test_or_with_model1
     expected = Post.where('id = 1 or id = 2').to_a
     assert_equal expected, Post.where('id = 1').or(Post.where('id = 2')).to_a
@@ -46,9 +47,10 @@ class RailsOrTest < Minitest::Test
     assert_equal expected, Post.where('id = 1').or('id = ? OR id = ?', 2, 3).to_a
     assert_equal expected, Post.where('id = 1').or('id = ?', 2).or('id = ?', 3).to_a
   end
-#--------------------------------
-#  Common condition
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● Common condition
+  # ----------------------------------------------------------------
   def test_or_with_shared_where 
     expected = Post.where('id = 1 and (title = ? or title = ?)', "John's post1", "John's post2").to_a
     target = Post.where('id = 1').where(:title => "John's post1").or(Post.where('id = 1').where(:title => "John's post2"))
@@ -71,31 +73,35 @@ class RailsOrTest < Minitest::Test
     #Correct: SELECT "users".* FROM "users"  WHERE ("users"."id" = 1 OR "users"."id" = 2)
     assert_equal 1, User.where(:id => 1).or(:id => 2).to_sql.count('(')
   end
-#--------------------------------
-#  Multiple columns
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● Multiple columns
+  # ----------------------------------------------------------------
   def test_or_with_multiple_attributes
     expected = Post.where('id = 1 or title = ?', "Kathenrie's post1").to_a
     assert_equal expected, Post.where('id = 1').or(:title => "Kathenrie's post1").to_a
   end
-#--------------------------------
-#  join
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● join
+  # ----------------------------------------------------------------
   def test_or_with_join
     expected = User.joins(:posts).where('user_id = 1 AND (title = ? OR title = ? OR title = ?)', "John's post1", "John's post2", "John's post3").to_a
     assert_equal expected, User.joins(:posts).where('0')
                                .or(:id => 1, :'posts.title' => "John's post1")
                                .or(:id => 1, :'posts.title' => "John's post2")
-                               .or(:id => 1, :'posts.title' => "John's post3").to_a
+                               .or(:id => 1, :'posts.title' => "John's post3")
+                               .to_a
   end
 
   def test_or_with_join_and_no_join
     expected = User.joins(:posts).where('user_id = 1 AND title = ? OR user_id = 2', "John's post2").to_a
     assert_equal expected, User.joins(:posts).where(:id => 1, :'posts.title' => "John's post2").or(:id => 2).to_a
   end
-#--------------------------------
-#  having
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● having
+  # ----------------------------------------------------------------
   def test_or_with_having
     expected = Post.group(:user_id).having("COUNT(*) = 1 OR COUNT(*) = 2").to_a
     assert_equal expected, Post.group(:user_id).having("COUNT(*) = 1").or(Post.group(:user_id).having("COUNT(*) = 2")).to_a
@@ -106,9 +112,10 @@ class RailsOrTest < Minitest::Test
     expected = User.joins(:posts).group(:user_id).having("COUNT(*) = 1 OR COUNT(*) > 1").to_a
     assert_equal expected, User.joins(:posts).group(:user_id).having("COUNT(*) > 1").or_having("COUNT(*) = 1").to_a
   end
-#--------------------------------
-#  uniq / limit / offset / order
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● uniq / limit / offset / order
+  # ----------------------------------------------------------------
   def test_or_with_limit
     expected = Post.where('user_id = 1 OR user_id = 2').limit(4).to_a
     assert_equal expected, Post.limit(4).where(:user_id => 1).or(:user_id => 2).to_a
@@ -128,9 +135,10 @@ class RailsOrTest < Minitest::Test
     expected = Post.where('user_id = 1 OR user_id = 2 OR user_id = 3').order('user_id desc').pluck(:user_id)
     assert_equal expected, Post.order('user_id desc').where(:user_id => 1).or(:user_id => 2).or(:user_id => 3).pluck(:user_id)
   end
-#--------------------------------
-#  logic order
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● logic order
+  # ----------------------------------------------------------------
   def test_A_and_B_or_C # (A && B) || C, C || (B && A)
     expected = Post.where('(user_id = ? AND title = ?) OR user_id = ?', 1, "John's post1", 2).to_a
     assert_equal expected, Post.where(:user_id => 1).where(:title => "John's post1").or(:user_id => 2).to_a
@@ -158,9 +166,10 @@ class RailsOrTest < Minitest::Test
       assert_equal expected, Post.where.not('title LIKE ?', "Pearl's %").or(Post.where.not(:user_id => 1).where('title LIKE ?', "Kathenrie's %")).to_a
     end
   end
-#--------------------------------
-#  Nested
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● Nested
+  # ----------------------------------------------------------------
   def test_nested_or # (A && (B || C)) || D, ((B || C) && A) || D
     expected = Post.where('(title like ?) AND (start_time IS NULL OR start_time > ?) OR (title = ?)', 'John%', Time.parse('2016/1/15'), "Pearl's post1").pluck(:title)
     p1 = Post.with_title_like('John%').where('start_time IS NULL OR start_time > ?', Time.parse('2016/1/15'))
@@ -169,9 +178,10 @@ class RailsOrTest < Minitest::Test
     p1 = Post.where(:start_time => nil).or('start_time > ?', Time.parse('2016/1/15')).with_title_like('John%')
     assert_equal expected, p1.or(:title => "Pearl's post1").pluck(:title)
   end
-#--------------------------------
-#  Association test
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● Association test
+  # ----------------------------------------------------------------
   def test_two_has_many_result # model.others1 || model.others2
     user = User.where(:name => 'John').first
     assert_equal user.sent_messages.or(user.received_messages).pluck(:content), [
@@ -180,9 +190,10 @@ class RailsOrTest < Minitest::Test
       "user3 send to user1",
     ]
   end
-#--------------------------------
-#  Scope test
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● Scope test
+  # ----------------------------------------------------------------
   def test_two_scope
     u1 = User.where(:name => 'John').first
     u2 = User.where(:name => 'Pearl').first
@@ -209,9 +220,10 @@ class RailsOrTest < Minitest::Test
       "Pearl's post2",
     ]
   end
-#--------------------------------
-#  From Rails 5
-#--------------------------------
+
+  # ----------------------------------------------------------------
+  # ● From Rails 5
+  # ----------------------------------------------------------------
   def test_or_with_relation
     expected = Post.where('id = 1 or id = 2').to_a
     assert_equal expected, Post.where('id = 1').or(Post.where('id = 2')).to_a
@@ -232,10 +244,11 @@ class RailsOrTest < Minitest::Test
     expected = Post.all.to_a
     assert_equal expected, Post.where('id = 1').or(Post.where('')).to_a
   end
-#--------------------------------
-#  test other gem
-#--------------------------------
-  def test_if_method_all_return_array #EX: gem activerecord-deprecated_finders will change #all in Rails 4
+
+  # ----------------------------------------------------------------
+  # ● test other gem
+  # ----------------------------------------------------------------
+  def test_if_method_all_return_array # EX: gem activerecord-deprecated_finders will change #all in Rails 4
     expected = Post.where('id = 1 or id = 2').to_a
     p1 = Post.where(:id => 1)
     p2 = Post.where(:id => 2)

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -81,7 +81,7 @@ class RailsOrTest < Minitest::Test
 #--------------------------------
 #  join
 #--------------------------------
-  def test_or_with_join #Rails 5 doesn't support this
+  def test_or_with_join
     expected = User.joins(:posts).where('user_id = 1 AND (title = ? OR title = ? OR title = ?)', "John's post1", "John's post2", "John's post3").to_a
     assert_equal expected, User.joins(:posts).where('0')
                                .or(:id => 1, :'posts.title' => "John's post1")
@@ -89,7 +89,7 @@ class RailsOrTest < Minitest::Test
                                .or(:id => 1, :'posts.title' => "John's post3").to_a
   end
 
-  def test_or_with_join_and_no_join #Rails 5 doesn't support this
+  def test_or_with_join_and_no_join
     expected = User.joins(:posts).where('user_id = 1 AND title = ? OR user_id = 2', "John's post2").to_a
     assert_equal expected, User.joins(:posts).where(:id => 1, :'posts.title' => "John's post2").or(:id => 2).to_a
   end

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -122,8 +122,9 @@ class RailsOrTest < Minitest::Test
   end
 
   def test_or_with_uniq
-    expected = Post.distinct.where('user_id = 1 OR user_id = 2').pluck(:user_id)
-    assert_equal expected, Post.distinct.where(:user_id => 1).or(:user_id => 2).pluck(:user_id)
+    posts = (Post.respond_to?(:distinct) ? Post.distinct : Post.uniq)
+    expected = posts.where('user_id = 1 OR user_id = 2').pluck(:user_id)
+    assert_equal expected, posts.where(:user_id => 1).or(:user_id => 2).pluck(:user_id)
   end
 
   def test_or_with_offset

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -4,6 +4,7 @@ class RailsOrTest < Minitest::Test
   def setup
     
   end
+  
   def test_that_it_has_a_version_number
     refute_nil ::RailsOr::VERSION
   end
@@ -114,8 +115,8 @@ class RailsOrTest < Minitest::Test
   end
 
   def test_or_with_uniq #Rails 5 doesn't support this
-    expected = Post.uniq.where('user_id = 1 OR user_id = 2').pluck(:user_id)
-    assert_equal expected, Post.uniq.where(:user_id => 1).or(:user_id => 2).pluck(:user_id)
+    expected = Post.distinct.where('user_id = 1 OR user_id = 2').pluck(:user_id)
+    assert_equal expected, Post.distinct.where(:user_id => 1).or(:user_id => 2).pluck(:user_id)
   end
 
   def test_or_with_offset #Rails 5 doesn't support this

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -256,11 +256,11 @@ class RailsOrTest < Minitest::Test
   def test_or_on_loaded_relation
     expected = Post.where('id = 1 or id = 2').to_a
     p = Post.where('id = 1')
-    p.load
+    p.map(&:id) # p.load # Rails 3 doesn't have load method
     assert_equal p.loaded?, true
     assert_equal expected, p.or(Post.where('id = 2')).to_a
   end
-  
+
   # ----------------------------------------------------------------
   # ● test other gem
   # ----------------------------------------------------------------

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -14,26 +14,32 @@ class RailsOrTest < Minitest::Test
     expected = Post.where('id = 1 or id = 2').to_a
     assert_equal expected, Post.where('id = 1').or(Post.where('id = 2')).to_a
   end
+
   def test_or_with_model2
     expected = Post.where('id = 1 or id = 2').to_a
     assert_equal expected, Post.where(:id => 1).or(Post.where(:id => 2)).to_a
   end
+
   def test_or_with_string_argument
     expected = Post.where('id = 1 or id = 2').to_a
     assert_equal expected, Post.where('id = 1').or('id = 2').to_a
   end
+
   def test_or_with_hash_argument
     expected = Post.where('id = 1 or id = 2').to_a
     assert_equal expected, Post.where('id = 1').or(:id => 2).to_a
   end
+
   def test_or_with_array_argument
     expected = Post.where('id = 1 or id = 2').to_a
     assert_equal expected, Post.where('id = 1').or(['id = ?', 2]).to_a
   end
+
   def test_or_with_multiple_arguments1
     expected = Post.where('id = ? or id = ?', 1, 2).to_a
     assert_equal expected, Post.where('id = 1').or('id = ?', 2).to_a
   end
+
   def test_or_with_multiple_arguments2
     expected = Post.where('id = ? or id = ? or id = ?', 1, 2, 3).to_a
     assert_equal expected, Post.where('id = 1').or('id = ? OR id = ?', 2, 3).to_a
@@ -74,49 +80,52 @@ class RailsOrTest < Minitest::Test
 #--------------------------------
 #  join
 #--------------------------------
-  if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('5.0.0')
-    def test_or_with_join #Rails 5 doesn't support this
-      expected = User.joins(:posts).where('user_id = 1 AND (title = ? OR title = ? OR title = ?)', "John's post1", "John's post2", "John's post3").to_a
-      assert_equal expected, User.joins(:posts).where('0')
-                                 .or(:id => 1, :'posts.title' => "John's post1")
-                                 .or(:id => 1, :'posts.title' => "John's post2")
-                                 .or(:id => 1, :'posts.title' => "John's post3").to_a
-    end
-    def test_or_with_join_and_no_join #Rails 5 doesn't support this
-      expected = User.joins(:posts).where('user_id = 1 AND title = ? OR user_id = 2', "John's post2").to_a
-      assert_equal expected, User.joins(:posts).where(:id => 1, :'posts.title' => "John's post2").or(:id => 2).to_a
-    end
+  def test_or_with_join #Rails 5 doesn't support this
+    expected = User.joins(:posts).where('user_id = 1 AND (title = ? OR title = ? OR title = ?)', "John's post1", "John's post2", "John's post3").to_a
+    assert_equal expected, User.joins(:posts).where('0')
+                               .or(:id => 1, :'posts.title' => "John's post1")
+                               .or(:id => 1, :'posts.title' => "John's post2")
+                               .or(:id => 1, :'posts.title' => "John's post3").to_a
+  end
+
+  def test_or_with_join_and_no_join #Rails 5 doesn't support this
+    expected = User.joins(:posts).where('user_id = 1 AND title = ? OR user_id = 2', "John's post2").to_a
+    assert_equal expected, User.joins(:posts).where(:id => 1, :'posts.title' => "John's post2").or(:id => 2).to_a
+  end
 #--------------------------------
 #  having
 #--------------------------------
-    def test_or_with_having #Rails 5 doesn't support this
-      expected = Post.group(:user_id).having("COUNT(*) = 1 OR COUNT(*) = 2").to_a
-      assert_equal expected, Post.group(:user_id).having("COUNT(*) = 1").or(Post.having("COUNT(*) = 2")).to_a
-      assert_equal expected, Post.group(:user_id).having("COUNT(*) = 1").or_having("COUNT(*) = 2").to_a
-    end
-    def test_or_with_join_and_having #Rails 5 doesn't support this
-      expected = User.joins(:posts).group(:user_id).having("COUNT(*) = 1 OR COUNT(*) > 1").to_a
-      assert_equal expected, User.joins(:posts).group(:user_id).having("COUNT(*) > 1").or_having("COUNT(*) = 1").to_a
-    end
+  def test_or_with_having #Rails 5 doesn't support this
+    expected = Post.group(:user_id).having("COUNT(*) = 1 OR COUNT(*) = 2").to_a
+    assert_equal expected, Post.group(:user_id).having("COUNT(*) = 1").or(Post.having("COUNT(*) = 2")).to_a
+    assert_equal expected, Post.group(:user_id).having("COUNT(*) = 1").or_having("COUNT(*) = 2").to_a
+  end
+
+  def test_or_with_join_and_having #Rails 5 doesn't support this
+    expected = User.joins(:posts).group(:user_id).having("COUNT(*) = 1 OR COUNT(*) > 1").to_a
+    assert_equal expected, User.joins(:posts).group(:user_id).having("COUNT(*) > 1").or_having("COUNT(*) = 1").to_a
+  end
 #--------------------------------
 #  uniq / limit / offset / order
 #--------------------------------
-    def test_or_with_limit #Rails 5 doesn't support this
-      expected = Post.where('user_id = 1 OR user_id = 2').limit(4).to_a
-      assert_equal expected, Post.limit(4).where(:user_id => 1).or(:user_id => 2).to_a
-    end
-    def test_or_with_uniq #Rails 5 doesn't support this
-      expected = Post.uniq.where('user_id = 1 OR user_id = 2').pluck(:user_id)
-      assert_equal expected, Post.uniq.where(:user_id => 1).or(:user_id => 2).pluck(:user_id)
-    end
-    def test_or_with_offset #Rails 5 doesn't support this
-      expected = Post.where('user_id = 1 OR user_id = 2').offset(3).first
-      assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).offset(3).first
-    end
-    def test_or_with_order #Rails 5 doesn't support this
-      expected = Post.where('user_id = 1 OR user_id = 2 OR user_id = 3').order('user_id desc').pluck(:user_id)
-      assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).or(:user_id => 3).order('user_id desc').pluck(:user_id)
-    end
+  def test_or_with_limit #Rails 5 doesn't support this
+    expected = Post.where('user_id = 1 OR user_id = 2').limit(4).to_a
+    assert_equal expected, Post.limit(4).where(:user_id => 1).or(:user_id => 2).to_a
+  end
+
+  def test_or_with_uniq #Rails 5 doesn't support this
+    expected = Post.uniq.where('user_id = 1 OR user_id = 2').pluck(:user_id)
+    assert_equal expected, Post.uniq.where(:user_id => 1).or(:user_id => 2).pluck(:user_id)
+  end
+
+  def test_or_with_offset #Rails 5 doesn't support this
+    expected = Post.where('user_id = 1 OR user_id = 2').offset(3).first
+    assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).offset(3).first
+  end
+
+  def test_or_with_order #Rails 5 doesn't support this
+    expected = Post.where('user_id = 1 OR user_id = 2 OR user_id = 3').order('user_id desc').pluck(:user_id)
+    assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).or(:user_id => 3).order('user_id desc').pluck(:user_id)
   end
 #--------------------------------
 #  logic order
@@ -126,10 +135,12 @@ class RailsOrTest < Minitest::Test
     assert_equal expected, Post.where(:user_id => 1).where(:title => "John's post1").or(:user_id => 2).to_a
     assert_equal expected, Post.where(:user_id => 2).or(Post.where(:title => "John's post1").where(:user_id => 1)).to_a
   end
+
   def test_A_or_B_and_C #(A || B) && C
     expected = Post.where('(user_id = ? OR user_id = ?) AND title LIKE ?', 1, 2, "John's %").to_a
     assert_equal expected, Post.where(:user_id => 1).or(:user_id => 2).where('title LIKE ?', "John's %").to_a
   end
+
   if Gem::Version.new(ActiveRecord::VERSION::STRING) > Gem::Version.new('4.0.2')
     def test_A_and_not_B_or_C #(A && !B) || C, C || (!B && A)
       expected = Post.where('(user_id = ? AND NOT title = ?) OR user_id = ?', 1, "John's post1", 2).to_a
@@ -204,15 +215,18 @@ class RailsOrTest < Minitest::Test
     expected = Post.where('id = 1 or id = 2').to_a
     assert_equal expected, Post.where('id = 1').or(Post.where('id = 2')).to_a
   end
+
   def test_or_identity
     expected = Post.where('id = 1').to_a
     assert_equal expected, Post.where('id = 1').or(Post.where('id = 1')).to_a
     assert_equal expected, Post.where(:id => 1).or(Post.where('id = 1')).to_a
   end
+
   def test_or_without_left_where
     expected = Post.all.to_a
     assert_equal expected, Post.or(Post.where('id = 1')).to_a
   end
+
   def test_or_without_right_where
     expected = Post.all.to_a
     assert_equal expected, Post.where('id = 1').or(Post.where('')).to_a

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -246,6 +246,21 @@ class RailsOrTest < Minitest::Test
     assert_equal expected, Post.where('id = 1').or(Post.where('')).to_a
   end
 
+  def test_or_preserves_other_querying_methods
+    expected = Post.where('id = 1 or id = 2 or id = 3').order('title asc').to_a
+    partial = Post.order('title asc')
+    assert_equal expected, partial.where('id = 1').or(partial.where(:id => [2, 3])).to_a
+    assert_equal expected, Post.order('title asc').where('id = 1').or(Post.order('title asc').where(:id => [2, 3])).to_a
+  end
+
+  def test_or_on_loaded_relation
+    expected = Post.where('id = 1 or id = 2').to_a
+    p = Post.where('id = 1')
+    p.load
+    assert_equal p.loaded?, true
+    assert_equal expected, p.or(Post.where('id = 2')).to_a
+  end
+  
   # ----------------------------------------------------------------
   # ● test other gem
   # ----------------------------------------------------------------


### PR DESCRIPTION
Rails 5's `or` method have some compatible tests that may cause problems when you want to upgrade Rails from 4 to 5

See https://github.com/rails/rails/commit/b0b37942d729b6bdcd2e3178eda7fa1de203b3d0#diff-bf6dd6226db3aab589916f09236881c7R588
> The two relations must be structurally compatible: they must be scoping the same model, and they must differ only by +where+ (if no +group+ has been defined) or +having+ (if a +group+ is present). Neither relation may have a +limit+, +offset+, or +uniq+ set.
