### PR TITLE
Fix missing from_clause when using #from and #none together

### DIFF
--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -80,6 +80,7 @@ class ActiveRecord::Relation
     relation.order_values = self.order_values
     relation.offset_value = self.offset_value
     relation.references_values = self.references_values
+    relation.from_clause = self.from_clause
   end
 
   def rails_or_spwan_relation(method, condition)

--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -18,6 +18,8 @@ end
 class ActiveRecord::Relation
   IS_RAILS3_FLAG = Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
   IS_RAILS5_FLAG = Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.0.0')
+  FROM_VALUE_METHOD = %i[from_value from_clause].find{|s| method_defined?(s) }
+  ASSIGN_FROM_VALUE = :"#{FROM_VALUE_METHOD}="
   if method_defined?(:or)
     if not method_defined?(:rails5_or)
       alias_method :rails5_or, :or
@@ -93,11 +95,11 @@ class ActiveRecord::Relation
     relation.order_values = self.order_values
     relation.offset_value = self.offset_value
     relation.references_values = self.references_values
-    relation.from_clause = self.from_clause
   end
 
   def rails_or_spwan_relation(method, condition)
     relation = klass.send(method, condition)
+    relation.send(ASSIGN_FROM_VALUE, send(FROM_VALUE_METHOD))
     rails_or_copy_values_to(relation) if IS_RAILS5_FLAG
     return relation
   end

--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -6,7 +6,7 @@ if defined?(ActiveRecord::NullRelation)
   module ActiveRecord::NullRelation
     if method_defined?(:or)
       if not method_defined?(:rails5_or)
-      alias_method :rails5_or, :or
+        alias_method :rails5_or, :or
         def or(*other)
           rails5_or(rails_or_parse_parameter(*other))
         end

--- a/lib/rails_or.rb
+++ b/lib/rails_or.rb
@@ -2,6 +2,19 @@ require "rails_or/version"
 require "rails_or/where_binding_mixs"
 require 'active_record'
 
+if defined?(ActiveRecord::NullRelation)
+  module ActiveRecord::NullRelation
+    if method_defined?(:or)
+      if not method_defined?(:rails5_or)
+      alias_method :rails5_or, :or
+        def or(*other)
+          rails5_or(rails_or_parse_parameter(*other))
+        end
+      end
+    end
+  end
+end
+
 class ActiveRecord::Relation
   IS_RAILS3_FLAG = Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
   IS_RAILS5_FLAG = Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.0.0')

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -290,4 +290,22 @@ class RailsOrTest < Minitest::Test
     assert_equal pearl.pluck(:id), pearl.or(none1).pluck(:id)
     assert_equal pearl.pluck(:id), pearl.or(none2).pluck(:id) if none2
   end
+
+  def test_or_with_from
+    users = User.from(User.where(name: ['John', 'Pearl']))
+    user1 = users.where('subquery.name': 'Kathenrie')
+    user2 = users.where('subquery.name': 'Pearl')
+    user1_or_2 = user1.or('subquery.name': 'Pearl')
+    assert_equal ['Pearl'], user1.or(user2).pluck('subquery.name')
+    assert_equal ['Pearl'], user1_or_2.pluck('subquery.name')
+  end
+
+  def test_or_with_from_and_none
+    users = User.from(User.where(name: ['John', 'Pearl']))
+    user1 = users.where('subquery.name': 'Kathenrie').none
+    user2 = users.where('subquery.name': 'Pearl')
+    user1_or_2 = user1.or('subquery.name': 'Pearl')
+    assert_equal ['Pearl'], user1.or(user2).pluck('subquery.name')
+    assert_equal ['Pearl'], user1_or_2.pluck('subquery.name')
+  end
 end

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -274,21 +274,13 @@ class RailsOrTest < Minitest::Test
   end
 
   def test_or_with_left_be_none
-    none1 = User.where('0')
-    none2 = User.none if User.respond_to?(:none)
     pearl = User.where(name: 'Pearl')
-
-    assert_equal pearl.pluck(:id), none1.or(pearl).pluck(:id)
-    assert_equal pearl.pluck(:id), none2.or(pearl).pluck(:id) if none2
+    assert_equal pearl.pluck(:id), User.none.or(pearl).pluck(:id)
   end
 
   def test_or_with_right_be_none
-    none1 = User.where('0')
-    none2 = User.none if User.respond_to?(:none)
     pearl = User.where(name: 'Pearl')
-
-    assert_equal pearl.pluck(:id), pearl.or(none1).pluck(:id)
-    assert_equal pearl.pluck(:id), pearl.or(none2).pluck(:id) if none2
+    assert_equal pearl.pluck(:id), pearl.or(User.none).pluck(:id)
   end
 
   def test_or_with_from

--- a/test/rails_or_test.rb
+++ b/test/rails_or_test.rb
@@ -293,18 +293,18 @@ class RailsOrTest < Minitest::Test
 
   def test_or_with_from
     users = User.from(User.where(name: ['John', 'Pearl']))
-    user1 = users.where('subquery.name': 'Kathenrie')
-    user2 = users.where('subquery.name': 'Pearl')
-    user1_or_2 = user1.or('subquery.name': 'Pearl')
+    user1 = users.where('subquery.name' => 'Kathenrie')
+    user2 = users.where('subquery.name' => 'Pearl')
+    user1_or_2 = user1.or('subquery.name' => 'Pearl')
     assert_equal ['Pearl'], user1.or(user2).pluck('subquery.name')
     assert_equal ['Pearl'], user1_or_2.pluck('subquery.name')
   end
 
   def test_or_with_from_and_none
     users = User.from(User.where(name: ['John', 'Pearl']))
-    user1 = users.where('subquery.name': 'Kathenrie').none
-    user2 = users.where('subquery.name': 'Pearl')
-    user1_or_2 = user1.or('subquery.name': 'Pearl')
+    user1 = users.where('subquery.name' => 'Kathenrie').none
+    user2 = users.where('subquery.name' => 'Pearl')
+    user1_or_2 = user1.or('subquery.name' => 'Pearl')
     assert_equal ['Pearl'], user1.or(user2).pluck('subquery.name')
     assert_equal ['Pearl'], user1_or_2.pluck('subquery.name')
   end

--- a/test/seeds.rb
+++ b/test/seeds.rb
@@ -25,6 +25,15 @@ class User < ActiveRecord::Base
   has_many :received_messages, :class_name => "UserMessage", :foreign_key => :receiver_user_id, :dependent => :destroy
 
   scope :none, ->{ where('0') } if not User.respond_to?(:none) # For Rails 3
+  if ActiveRecord::Relation::IS_RAILS3_FLAG
+    class << self
+      alias_method :origin_from, :from if not method_defined?(:origin_from)
+      def from(string)
+        return origin_from if string.is_a?(String)
+        return origin_from("(#{string.to_sql}) subquery") # Rails 3's #from only support string arguments
+      end
+    end
+  end  
 end
 class Post < ActiveRecord::Base
   belongs_to :user

--- a/test/seeds.rb
+++ b/test/seeds.rb
@@ -17,11 +17,14 @@ ActiveRecord::Schema.define do
     t.string :content
   end
 end
+
 class User < ActiveRecord::Base
   serialize :serialized_attribute, Hash
   has_many :posts
   has_many :sent_messages,     :class_name => "UserMessage", :foreign_key => :sender_user_id,   :dependent => :destroy
   has_many :received_messages, :class_name => "UserMessage", :foreign_key => :receiver_user_id, :dependent => :destroy
+
+  scope :none, ->{ where('0') } if not User.respond_to?(:none) # For Rails 3
 end
 class Post < ActiveRecord::Base
   belongs_to :user


### PR DESCRIPTION
### Using #from along will be OK
```rb
users = User.from(User.where(id: [1,2,3]))
users.where('subquery.id': 1).or('subquery.id': 2).pluck("subquery.id")
# SELECT subquery.id FROM (SELECT `users`.* FROM `users` WHERE `users`.`id` IN (1, 2, 3)) subquery WHERE (`subquery`.`id` = 1 OR `subquery`.`id` = 2)
# => [1, 2] 
```

### Using #from and #none together will make from clause disappear
```rb
users = User.from(User.where(id: [1,2,3]))
users.where('subquery.id': 1).none.or('subquery.id': 2).pluck("subquery.id")
# SELECT subquery.id FROM `users` WHERE `subquery`.`id` = 2
# ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'subquery.id' in 'field list': SELECT subquery.id FROM `users` WHERE `subquery`.`id` = 2
```