### PR TITLE
Drop the support of ruby 2.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.2
+          - 2.3
           - 2.6
           - 2.7
           - 3.0
@@ -62,11 +62,11 @@ jobs:
           - gemfile: 5.2.gemfile
             ruby: 3.1
           - gemfile: 6.0.gemfile
-            ruby: 2.2
+            ruby: 2.3
           - gemfile: 6.1.gemfile
-            ruby: 2.2
+            ruby: 2.3
           - gemfile: 7.0.gemfile
-            ruby: 2.2
+            ruby: 2.3
           - gemfile: 7.0.gemfile
             ruby: 2.6
     env:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 It will use built-in `or` method, which was added in Rails 5, when possible, so that you don't need to worry about that it will polulate `active_model`. Otherwise, it implements `or` method for Rails 3 and Rails 4.
 
 ## Supports
-- Ruby 2.2 ~ 2.7, 3.0 ~ 3.1
+- Ruby 2.3 ~ 2.7, 3.0 ~ 3.1
 - Rails 3.2, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1, 7.0
 
 ## Installation

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -23,6 +23,9 @@ end
 require 'rails_compatibility/setup_autoload_paths'
 RailsCompatibility.setup_autoload_paths [File.expand_path('../models/', __FILE__)]
 
+ActiveRecord::Base.use_yaml_unsafe_load = true if ActiveRecord::Base.method_defined?(:use_yaml_unsafe_load) # For Rails 5.2
+ActiveRecord.use_yaml_unsafe_load = true if ActiveRecord.respond_to?(:use_yaml_unsafe_load) # For Rails 7.0
+
 users = User.create([
   { name: 'John', email: 'john@example.com' },
   { name: 'Pearl', email: 'pearl@example.com', serialized_attribute: { testing: true, deep: { deep: :deep }}},


### PR DESCRIPTION
since we encounter Segmentation fault and have no idea how to fix it

The error messages:

```
Installing Bundler
  /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v 1.17.3
  /opt/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/rubygems/source.rb:192: [BUG] Segmentation fault at 0x00000000000010
  ruby 2.2.10p489 (2018-03-28 revision 63023) [x86_64-linux]
```
